### PR TITLE
Fix message escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 
 const matchers = {
   "phpunit-failure": {
-      "regexp": "##teamcity\\[testFailed.+message='([^']+)'.+details='\\s+{{GITHUB_WORKSPACE}}/([^:]+):(\\d+)[^']+'",
+      "regexp": "##teamcity\\[testFailed.+message='(.+)'.+details='\\s+{{GITHUB_WORKSPACE}}/([^:]+):(\\d+)[^']+'",
       "defaultSeverity": "error",
       "message": 1,
       "file": 2,


### PR DESCRIPTION
This PR fixes #3, which has useful information being truncated due to an incorrect regex that stops at the first `'` detected. This change switches to a greedy matcher, which matches all characters until it encounters `'.+details`

Tested via https://problem-matcher.netlify.app/

Log input:

```
##teamcity[testFailed name='testDescribeJson' message='PDOException : SQLSTATE|[42000|]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near |'(3) DEFAULT CURRENT_TIMESTAMP(3),|' at line 9' details=' {{GITHUB_WORKSPACE}}/file.php:72|n ' duration='4' flowId='9424']
```

Test matcher:
```
{
  "owner": "eslint-stylish",
  "pattern": [
    {
      "regexp": "##teamcity\\[testFailed.+message='(.+)'.+details='\\s+{{GITHUB_WORKSPACE}}/([^:]+):(\\d+)[^']+'",
      "file": 2,
      "line": 3,
      "message": 1
    }
  ]
}
```