### PR TITLE
Add ability to customise the root folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       run: ./vendor/bin/phpunit --teamcity test
 ```
 
-If you run your tests in a container and the Teamcity output will have a different base path, you can specify it using the `root_folder` input:
+If you run your tests in a container and the Teamcity output will have a different base path, you can specify it using the `base_path` input:
 
 ```yaml
 - name: Configure matchers

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ jobs:
       run: ./vendor/bin/phpunit --teamcity test
 ```
 
+If you run your tests in a container and the Teamcity output will have a different base path, you can specify it using the `root_folder` input:
+
+```yaml
+- name: Configure matchers
+  uses: mheap/phpunit-matcher-action@v1
+  with:
+    base_path: /path/to/other/folder
+```
+
 ## How this works
 
 [Problem matchers](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md) work by defining a regular expression to extract information such as the file, line number and severity from any output logs. Each matcher has to be registered with Github Actions by adding `::add-matcher::/path/to/matcher.json` to the output.

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,13 @@
-name: 'PHPUnit Problem Matchers'
-author: 'Michael Heap'
-description: 'Adds problem matcher for PHPUnit'
+name: "PHPUnit Problem Matchers"
+author: "Michael Heap"
+description: "Adds problem matcher for PHPUnit"
 runs:
-  using: 'node12'
-  main: 'index.js'
+  using: "node12"
+  main: "index.js"
 branding:
-  icon: 'list'
-  color: 'green'
+  icon: "list"
+  color: "green"
+inputs:
+  base_path:
+    description: "The base path to strip from your test output to leave just relative paths"
+    required: false

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
 
 module.exports = function () {
+  const workspaceRoot =
+    process.env.INPUT_BASE_PATH || process.env.GITHUB_WORKSPACE || "";
   const matchers = {
     "phpunit-failure": {
       regexp:
@@ -23,7 +25,7 @@ module.exports = function () {
             {
               regexp: details.regexp.replace(
                 "{{GITHUB_WORKSPACE}}",
-                process.env.GITHUB_WORKSPACE || ""
+                workspaceRoot
               ),
               message: details.message,
               file: details.file,

--- a/index.test.js
+++ b/index.test.js
@@ -55,3 +55,22 @@ describe("with default GITHUB_WORKSPACE", () => {
     expect(fs.mkdirSync).not.toBeCalled();
   });
 });
+
+describe("with a custom base path", () => {
+  beforeEach(() => {
+    restore = mockedEnv({
+      INPUT_BASE_PATH: "/path/to/tests/in/container",
+    });
+  });
+
+  test("replaces {{ github_workspace }} correctly", () => {
+    jest.spyOn(fs, "existsSync").mockImplementation(() => true);
+    jest.spyOn(fs, "writeFileSync").mockImplementation();
+    jest.spyOn(console, "log").mockImplementation();
+    run();
+    expect(fs.writeFileSync).toBeCalledWith(
+      ".github/phpunit-failure.json",
+      '{"problemMatcher":[{"owner":"phpunit-failure","severity":"error","pattern":[{"regexp":"##teamcity\\\\[testFailed.+message=\'(.+)\'.+details=\'\\\\s+/path/to/tests/in/container/([^:]+):(\\\\d+)[^\']+\'","message":1,"file":2,"line":3}]}]}'
+    );
+  });
+});


### PR DESCRIPTION
> I run tests in a docker container built in previous job so teamcity log output has container path instead of github workspace path expected by this action.

> I would like to have an option to specify custom base path for the matcher.

@Xerkus Would this be enough to solve your issue?

Resolves #9