### PR TITLE
Upgrade to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "PHPUnit Problem Matchers"
 author: "Michael Heap"
 description: "Adds problem matcher for PHPUnit"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"
 branding:
   icon: "list"


### PR DESCRIPTION
Since Node.js 12 actions are deprecated, this small modification will used Node.js 16 instead as described here https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions