### PR TITLE
Fix regular expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function () {
   const matchers = {
     "phpunit-failure": {
       regexp:
-        "##teamcity\\[testFailed.+message='(.+)'.+details='\\s+{{GITHUB_WORKSPACE}}/([^:]+):(\\d+)[^']+'",
+        "##teamcity\\[testFailed.+message='(.+)'.+details='\\s*{{GITHUB_WORKSPACE}}/([^:]+):(\\d+)[^']+'",
       defaultSeverity: "error",
       message: 1,
       file: 2,


### PR DESCRIPTION
I don’t know where the "one or more spaces" could come from but my line looks like this:

```
##teamcity[testFailed name='testName' message='Failed asserting that null is not null.' details='/path/to/test.php:36|n' duration='5' flowId='24753']
```